### PR TITLE
gx: update go-libp2p-peerstore

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.0.4: QmSAJm4QdTJ3EGF2cvgNcQyXTEbxqWSW1x4kCVV1aJQUQr
+0.0.5: QmayGe6p6EJT8sbdmsh5eyVjp9u8KvFwkMacKwx2MDWzN8

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmU4vCDZTPLDqSDKguWbHCiUe46mZUtmM2g2suBZ9NE8ko",
+      "hash": "Qmegn1aFLQmbCg4xurYgLug9TJ3rTVFjJ3L5fD3m9m4qMf",
       "name": "go-libp2p-net",
-      "version": "2.0.3"
+      "version": "2.0.4"
     }
   ],
   "gxVersion": "0.11.0",
@@ -19,6 +19,6 @@
   "license": "",
   "name": "go-libp2p-interface-connmgr",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.0.4"
+  "version": "0.0.5"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-libp2p-net/pull/18
- https://github.com/libp2p/go-libp2p-metrics/pull/11


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace