### PR TITLE
Add peer protection capability

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	inet "github.com/libp2p/go-libp2p-net"
-	"github.com/libp2p/go-libp2p-peer"
+	peer "github.com/libp2p/go-libp2p-peer"
 )
 
 // ConnManager tracks connections to peers, and allows consumers to associate metadata
@@ -33,10 +33,16 @@ type ConnManager interface {
 	Notifee() inet.Notifiee
 
 	// Protect protects a peer from having its connection(s) pruned.
-	Protect(peer.ID)
+	//
+	// Calls to Protect() with the same tag are idempotent. They are not refcounted, so after multiple Protect()
+	// calls with the same tag, a single Unprotect() call bearing the same tag will revoke the protection.
+	Protect(id peer.ID, tag string)
 
-	// Unprotect removes any protection that may have been placed on a peer.
-	Unprotect(peer.ID)
+	// Unprotect removes a protection that may have been placed on a peer, under the specified tag.
+	//
+	// The return value indicates whether the peer continues to be protected after this call, by way of a different tag.
+	// See notes on Protect() for more info.
+	Unprotect(id peer.ID, tag string) (protected bool)
 }
 
 // TagInfo stores metadata associated with a peer.

--- a/interface.go
+++ b/interface.go
@@ -34,8 +34,10 @@ type ConnManager interface {
 
 	// Protect protects a peer from having its connection(s) pruned.
 	//
-	// Calls to Protect() with the same tag are idempotent. They are not refcounted, so after multiple Protect()
-	// calls with the same tag, a single Unprotect() call bearing the same tag will revoke the protection.
+	// Tagging allows different parts of the system to manage protections without interfering with one another.
+	//
+	// Calls to Protect() with the same tag are idempotent. They are not refcounted, so after multiple calls
+	// to Protect() with the same tag, a single Unprotect() call bearing the same tag will revoke the protection.
 	Protect(id peer.ID, tag string)
 
 	// Unprotect removes a protection that may have been placed on a peer, under the specified tag.

--- a/interface.go
+++ b/interface.go
@@ -31,6 +31,12 @@ type ConnManager interface {
 	// Notifee returns an implementation that can be called back to inform of
 	// opened and closed connections.
 	Notifee() inet.Notifiee
+
+	// Protect protects a peer from having its connection(s) pruned.
+	Protect(peer.ID)
+
+	// Unprotect removes any protection that may have been placed on a peer.
+	Unprotect(peer.ID)
 }
 
 // TagInfo stores metadata associated with a peer.


### PR DESCRIPTION
This enhances the interface with the ability to protect and unprotect peers from pruning.

Enables https://github.com/ipfs/go-ipfs/issues/6097.