### PR TITLE
Add Close method to the ConnManager interface

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -52,6 +52,9 @@ type ConnManager interface {
 	// The return value indicates whether the peer continues to be protected after this call, by way of a different tag.
 	// See notes on Protect() for more info.
 	Unprotect(id peer.ID, tag string) (protected bool)
+
+	// Close closes the connection manager and stops background processes
+	Close() error
 }
 
 // TagInfo stores metadata associated with a peer.

--- a/null.go
+++ b/null.go
@@ -20,6 +20,7 @@ func (_ NullConnMgr) TrimOpenConns(context.Context)            {}
 func (_ NullConnMgr) Notifee() inet.Notifiee                   { return &cmNotifee{} }
 func (_ NullConnMgr) Protect(peer.ID, string)                  {}
 func (_ NullConnMgr) Unprotect(peer.ID, string) bool           { return false }
+func (_ NullConnMgr) Close() error                             { return nil }
 
 type cmNotifee struct{}
 


### PR DESCRIPTION
Necessary now that the connection manager gets a background worker in https://github.com/libp2p/go-libp2p-connmgr/pull/43